### PR TITLE
Prevent wallclimb

### DIFF
--- a/Assets/LEGO/Scripts/LEGO Minifig/MinifigController.cs
+++ b/Assets/LEGO/Scripts/LEGO Minifig/MinifigController.cs
@@ -262,6 +262,15 @@ namespace Unity.LEGO.Minifig
                     float angle = Vector3.Angle(hit.normal, Vector3.up);
                     isSliding = angle > controller.slopeLimit;
                     
+                    // Check if object has the SlideOnObject component
+                    if (hit.collider.gameObject.TryGetComponent<SlideOnObject>(out var slideOnObject))
+                    {
+                        if (slideOnObject.slideEnabled)
+                        {
+                            isSliding = true;
+                        }
+                    }
+                    
                     if (isSliding)
                     {
                         Vector3 slidingRotation = new Vector3(hit.normal.x, 0f, hit.normal.z).normalized;

--- a/Assets/LEGO/Scripts/LEGO Minifig/SlideOnObject.cs
+++ b/Assets/LEGO/Scripts/LEGO Minifig/SlideOnObject.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// Just attach this script if you want the player to slide on it
+public class SlideOnObject : MonoBehaviour
+{
+    public bool slideEnabled = true;
+}

--- a/Assets/LEGO/Scripts/LEGO Minifig/SlideOnObject.cs.meta
+++ b/Assets/LEGO/Scripts/LEGO Minifig/SlideOnObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8b859db5a692c74e9dcc352d6c288a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR prevents the player from spamming jump to climb up steep surfaces. Now, using the max slope set in the PlayerController, the player will slide down any surfaces that are too steep. You can even make slides with this if they're steep enough.

Try it out! I've been testing it in the tutorial level with the large cliifs. Now we don't need a bunch of colliders to stop the player anymore. 

Also includes a SlideOnObject script. You can attach this script to any GameObject with a collider to force the player to slide when they stand on it. You can also toggle it through a public bool variable in the script.