### PR TITLE
Disable lever handle collision

### DIFF
--- a/Assets/Final Project/Prefabs/Components/Lever.prefab
+++ b/Assets/Final Project/Prefabs/Components/Lever.prefab
@@ -243,7 +243,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017578312877}
   - component: {fileID: 2558083017578312876}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: 30553
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -297,7 +297,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017587935707}
   - component: {fileID: 2558083017587935704}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -472,7 +472,7 @@ GameObject:
   - component: {fileID: 2558083017617528726}
   - component: {fileID: 2558083017617528729}
   - component: {fileID: 2558083017617528727}
-  m_Layer: 13
+  m_Layer: 14
   m_Name: AxleField crossAxleConnector
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -546,7 +546,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017626794333}
   - component: {fileID: 2558083017626794330}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -590,7 +590,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017628612174}
   - component: {fileID: 2558083017628612175}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -634,7 +634,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017634772403}
   - component: {fileID: 2558083017634772400}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -683,7 +683,7 @@ GameObject:
   - component: {fileID: 2558083017648926022}
   - component: {fileID: 2558083017648926025}
   - component: {fileID: 2558083017648926024}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: 32123
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -866,7 +866,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017651713778}
   - component: {fileID: 2558083017651713779}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1054,7 +1054,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017665319191}
   - component: {fileID: 2558083017665319188}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1244,7 +1244,7 @@ GameObject:
   - component: {fileID: 2558083017692459761}
   - component: {fileID: 2558083017692459760}
   - component: {fileID: 2558083017692459763}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: 32062
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1384,7 +1384,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017698505781}
   - component: {fileID: 2558083017698505780}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Connectivity
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1472,7 +1472,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017710006374}
   - component: {fileID: 2558083017710006375}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1516,7 +1516,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017712756745}
   - component: {fileID: 2558083017712756742}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1561,7 +1561,7 @@ GameObject:
   - component: {fileID: 2558083017723244661}
   - component: {fileID: 2558083017723244659}
   - component: {fileID: 2558083017723244658}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Shell
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1641,7 +1641,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017730626948}
   - component: {fileID: 2558083017730626949}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1686,7 +1686,7 @@ GameObject:
   - component: {fileID: 2558083017743596326}
   - component: {fileID: 2558083017743596329}
   - component: {fileID: 2558083017743596327}
-  m_Layer: 12
+  m_Layer: 14
   m_Name: AxleField crossAxleReceptor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1853,7 +1853,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017749286942}
   - component: {fileID: 2558083017749286943}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1897,7 +1897,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017755199626}
   - component: {fileID: 2558083017755199627}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2038,7 +2038,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017761456458}
   - component: {fileID: 2558083017761456459}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2082,7 +2082,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017765021629}
   - component: {fileID: 2558083017765021628}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Connectivity
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2135,7 +2135,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017766284538}
   - component: {fileID: 2558083017766284541}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2243,7 +2243,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017787478921}
   - component: {fileID: 2558083017787478918}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2425,7 +2425,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017808701837}
   - component: {fileID: 2558083017808701834}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2567,7 +2567,7 @@ GameObject:
   - component: {fileID: 2558083017829926821}
   - component: {fileID: 2558083017829926819}
   - component: {fileID: 2558083017829926818}
-  m_Layer: 12
+  m_Layer: 14
   m_Name: Custom2DField
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2813,7 +2813,7 @@ GameObject:
   - component: {fileID: 2558083017837789798}
   - component: {fileID: 2558083017837789801}
   - component: {fileID: 2558083017837789800}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: 30553
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3076,7 +3076,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017870543320}
   - component: {fileID: 2558083017870543321}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3120,7 +3120,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017873857358}
   - component: {fileID: 2558083017873857359}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 5
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3164,7 +3164,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017882152265}
   - component: {fileID: 2558083017882152262}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3208,7 +3208,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017883716809}
   - component: {fileID: 2558083017883716806}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3451,7 +3451,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017900731805}
   - component: {fileID: 2558083017900731802}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: 32123
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3505,7 +3505,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017903237742}
   - component: {fileID: 2558083017903237743}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 6
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3646,7 +3646,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017922503115}
   - component: {fileID: 2558083017922503112}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3735,7 +3735,7 @@ GameObject:
   - component: {fileID: 2558083017932755817}
   - component: {fileID: 2558083017932755815}
   - component: {fileID: 2558083017932755814}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Shell
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4240,7 +4240,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017957702257}
   - component: {fileID: 2558083017957702256}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4285,7 +4285,7 @@ GameObject:
   - component: {fileID: 2558083017959542082}
   - component: {fileID: 2558083017959542084}
   - component: {fileID: 2558083017959542085}
-  m_Layer: 13
+  m_Layer: 14
   m_Name: FixedField 13_connector
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4348,7 +4348,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017968151722}
   - component: {fileID: 2558083017968151723}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5060,7 +5060,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017993173302}
   - component: {fileID: 2558083017993173303}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5201,7 +5201,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083017995058672}
   - component: {fileID: 2558083017995058673}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5488,7 +5488,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018014462041}
   - component: {fileID: 2558083018014462038}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5839,7 +5839,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018026299015}
   - component: {fileID: 2558083018026299012}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6082,7 +6082,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018050513815}
   - component: {fileID: 2558083018050513812}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6126,7 +6126,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018055188224}
   - component: {fileID: 2558083018055188225}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 5
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6223,7 +6223,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018077547786}
   - component: {fileID: 2558083018077547789}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6412,7 +6412,7 @@ GameObject:
   - component: {fileID: 2558083018099357001}
   - component: {fileID: 2558083018099356999}
   - component: {fileID: 2558083018099356998}
-  m_Layer: 13
+  m_Layer: 14
   m_Name: FixedField 13_connector
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6653,7 +6653,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018117043065}
   - component: {fileID: 2558083018117043064}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6697,7 +6697,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018120301747}
   - component: {fileID: 2558083018120301746}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6869,7 +6869,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018140664302}
   - component: {fileID: 2558083018140664303}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 6
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7090,7 +7090,7 @@ GameObject:
   - component: {fileID: 2558083018164096868}
   - component: {fileID: 2558083018164096866}
   - component: {fileID: 2558083018164096869}
-  m_Layer: 12
+  m_Layer: 14
   m_Name: Custom2DField
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7235,7 +7235,7 @@ GameObject:
   - component: {fileID: 2558083018164218320}
   - component: {fileID: 2558083018164218318}
   - component: {fileID: 2558083018164218321}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Shell
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7465,7 +7465,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018174666546}
   - component: {fileID: 2558083018174666547}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: 32123
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7550,7 +7550,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018198787996}
   - component: {fileID: 2558083018198787999}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7594,7 +7594,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018207967189}
   - component: {fileID: 2558083018207967188}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7639,7 +7639,7 @@ GameObject:
   - component: {fileID: 2558083018211978125}
   - component: {fileID: 2558083018211978123}
   - component: {fileID: 2558083018211978122}
-  m_Layer: 12
+  m_Layer: 14
   m_Name: Custom2DField
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7861,7 +7861,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018232376699}
   - component: {fileID: 2558083018232376698}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Colliders
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7939,7 +7939,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018244335125}
   - component: {fileID: 2558083018244335122}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7984,7 +7984,7 @@ GameObject:
   - component: {fileID: 2558083018247169377}
   - component: {fileID: 2558083018247169376}
   - component: {fileID: 2558083018247169374}
-  m_Layer: 12
+  m_Layer: 14
   m_Name: AxleField crossAxleReceptor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8054,7 +8054,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018257005206}
   - component: {fileID: 2558083018257005207}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8179,7 +8179,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018257412827}
   - component: {fileID: 2558083018257412824}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8223,7 +8223,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018261607026}
   - component: {fileID: 2558083018261607027}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8359,7 +8359,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018310737007}
   - component: {fileID: 2558083018310737006}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8403,7 +8403,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018313610561}
   - component: {fileID: 2558083018313610558}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8447,7 +8447,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018314321791}
   - component: {fileID: 2558083018314321788}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8491,7 +8491,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018320923127}
   - component: {fileID: 2558083018320923124}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9050,7 +9050,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018354987132}
   - component: {fileID: 2558083018354987135}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9125,7 +9125,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018370392757}
   - component: {fileID: 2558083018370392754}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 5
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9170,7 +9170,7 @@ GameObject:
   - component: {fileID: 2558083018377924866}
   - component: {fileID: 2558083018377924869}
   - component: {fileID: 2558083018377924867}
-  m_Layer: 12
+  m_Layer: 14
   m_Name: AxleField roundAxleReceptor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9240,7 +9240,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018378502284}
   - component: {fileID: 2558083018378502285}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9381,7 +9381,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018388008069}
   - component: {fileID: 2558083018388008066}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9425,7 +9425,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018400917315}
   - component: {fileID: 2558083018400917312}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 5
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9549,7 +9549,7 @@ GameObject:
   - component: {fileID: 2558083018419464500}
   - component: {fileID: 2558083018419464502}
   - component: {fileID: 2558083018419464503}
-  m_Layer: 12
+  m_Layer: 14
   m_Name: AxleField crossAxleReceptor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9716,7 +9716,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018425231083}
   - component: {fileID: 2558083018425231080}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9760,7 +9760,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018426337467}
   - component: {fileID: 2558083018426337466}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10030,7 +10030,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018445875539}
   - component: {fileID: 2558083018445875538}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10074,7 +10074,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018452524690}
   - component: {fileID: 2558083018452524693}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Colliders
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10268,7 +10268,7 @@ GameObject:
   - component: {fileID: 2558083018478145271}
   - component: {fileID: 2558083018478145270}
   - component: {fileID: 2558083018478145273}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: 32013
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10455,7 +10455,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018500446075}
   - component: {fileID: 2558083018500446072}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10543,7 +10543,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018519045948}
   - component: {fileID: 2558083018519045949}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10587,7 +10587,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018519592630}
   - component: {fileID: 2558083018519592631}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11085,7 +11085,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018551346600}
   - component: {fileID: 2558083018551346603}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: 32062
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11183,7 +11183,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018555598484}
   - component: {fileID: 2558083018555598485}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11227,7 +11227,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018557601735}
   - component: {fileID: 2558083018557601732}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11319,7 +11319,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018579039754}
   - component: {fileID: 2558083018579039755}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Connectivity
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11406,7 +11406,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2558083018603082860}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Handle_Parent
   m_TagString: Interactable
   m_Icon: {fileID: 0}
@@ -11520,7 +11520,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018608935741}
   - component: {fileID: 2558083018608935738}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11709,7 +11709,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018637802234}
   - component: {fileID: 2558083018637802235}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11816,7 +11816,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018645421916}
   - component: {fileID: 2558083018645421917}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -12431,7 +12431,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018676207665}
   - component: {fileID: 2558083018676207664}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Colliders
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -12945,7 +12945,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018691312346}
   - component: {fileID: 2558083018691312347}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 5
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -12989,7 +12989,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018692485182}
   - component: {fileID: 2558083018692485183}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 5
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -13033,7 +13033,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018692965166}
   - component: {fileID: 2558083018692965167}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Colliders
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -13297,7 +13297,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018704976083}
   - component: {fileID: 2558083018704976080}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -13519,7 +13519,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018728776993}
   - component: {fileID: 2558083018728776990}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 6
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -13568,7 +13568,7 @@ GameObject:
   - component: {fileID: 2558083018730587342}
   - component: {fileID: 2558083018730587345}
   - component: {fileID: 2558083018730587344}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: 32062
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -13752,7 +13752,7 @@ GameObject:
   - component: {fileID: 2558083018738110330}
   - component: {fileID: 2558083018738110332}
   - component: {fileID: 2558083018738110333}
-  m_Layer: 13
+  m_Layer: 14
   m_Name: FixedField 13_connector
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -13815,7 +13815,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018741372985}
   - component: {fileID: 2558083018741372982}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 6
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14037,7 +14037,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018772227710}
   - component: {fileID: 2558083018772227713}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14191,7 +14191,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018797509404}
   - component: {fileID: 2558083018797509405}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14607,7 +14607,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018849195546}
   - component: {fileID: 2558083018849195547}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14682,7 +14682,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018861180992}
   - component: {fileID: 2558083018861180993}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14726,7 +14726,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018879474981}
   - component: {fileID: 2558083018879474980}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Connectivity
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14779,7 +14779,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018879571474}
   - component: {fileID: 2558083018879571477}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14823,7 +14823,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018885093688}
   - component: {fileID: 2558083018885093689}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14867,7 +14867,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018899240489}
   - component: {fileID: 2558083018899240488}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14911,7 +14911,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018912410037}
   - component: {fileID: 2558083018912410036}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -15084,7 +15084,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018953904747}
   - component: {fileID: 2558083018953904744}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -15129,7 +15129,7 @@ GameObject:
   - component: {fileID: 2558083018954624870}
   - component: {fileID: 2558083018954624868}
   - component: {fileID: 2558083018954624871}
-  m_Layer: 13
+  m_Layer: 14
   m_Name: FixedField 13_connector
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -15193,7 +15193,7 @@ GameObject:
   - component: {fileID: 2558083018960368130}
   - component: {fileID: 2558083018960368133}
   - component: {fileID: 2558083018960368131}
-  m_Layer: 13
+  m_Layer: 14
   m_Name: AxleField crossAxleConnector
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -15467,7 +15467,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083018985511366}
   - component: {fileID: 2558083018985511367}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -15710,7 +15710,7 @@ GameObject:
   - component: {fileID: 2558083019029293886}
   - component: {fileID: 2558083019029293889}
   - component: {fileID: 2558083019029293888}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Handle - Dynamic
   m_TagString: Interactable
   m_Icon: {fileID: 0}
@@ -16038,7 +16038,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019051834552}
   - component: {fileID: 2558083019051834553}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -16223,7 +16223,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019088389460}
   - component: {fileID: 2558083019088389461}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -16267,7 +16267,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019096855852}
   - component: {fileID: 2558083019096855853}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -16780,7 +16780,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019138683678}
   - component: {fileID: 2558083019138683679}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -16824,7 +16824,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019142563835}
   - component: {fileID: 2558083019142563834}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Colliders
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -17282,7 +17282,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019210037508}
   - component: {fileID: 2558083019210037509}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -17326,7 +17326,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019222837991}
   - component: {fileID: 2558083019222837988}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: 32013
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -17901,7 +17901,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019259258643}
   - component: {fileID: 2558083019259258640}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 6
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -17946,7 +17946,7 @@ GameObject:
   - component: {fileID: 2558083019273313508}
   - component: {fileID: 2558083019273313506}
   - component: {fileID: 2558083019273313509}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Shell
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -18026,7 +18026,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019283523396}
   - component: {fileID: 2558083019283523399}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: 32062
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -18365,7 +18365,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019297905598}
   - component: {fileID: 2558083019297905599}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 6
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -18657,7 +18657,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019343775280}
   - component: {fileID: 2558083019343775283}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -18826,7 +18826,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019368211337}
   - component: {fileID: 2558083019368211334}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -18920,7 +18920,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019371815198}
   - component: {fileID: 2558083019371815201}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -18964,7 +18964,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019397750019}
   - component: {fileID: 2558083019397750016}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -19008,7 +19008,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019398401842}
   - component: {fileID: 2558083019398401843}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -19052,7 +19052,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019399169898}
   - component: {fileID: 2558083019399169899}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -19096,7 +19096,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019400167633}
   - component: {fileID: 2558083019400167632}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -19507,7 +19507,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019441640180}
   - component: {fileID: 2558083019441640181}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Colliders
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -19866,7 +19866,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019465845040}
   - component: {fileID: 2558083019465845043}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Connectivity
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -19919,7 +19919,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019467893845}
   - component: {fileID: 2558083019467893842}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -20276,7 +20276,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019506639141}
   - component: {fileID: 2558083019506639140}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -20417,7 +20417,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019510392540}
   - component: {fileID: 2558083019510392543}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -20611,7 +20611,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019545106591}
   - component: {fileID: 2558083019545106588}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -20686,7 +20686,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019568506260}
   - component: {fileID: 2558083019568506261}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -20730,7 +20730,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019573519680}
   - component: {fileID: 2558083019573519681}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -20822,7 +20822,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019587142405}
   - component: {fileID: 2558083019587142404}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -20964,7 +20964,7 @@ GameObject:
   - component: {fileID: 2558083019596084477}
   - component: {fileID: 2558083019596084475}
   - component: {fileID: 2558083019596084474}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Shell
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -21224,7 +21224,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019637531811}
   - component: {fileID: 2558083019637531810}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Connectivity
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -21366,7 +21366,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019654039835}
   - component: {fileID: 2558083019654039832}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -21755,7 +21755,7 @@ GameObject:
   - component: {fileID: 2558083019668785836}
   - component: {fileID: 2558083019668785838}
   - component: {fileID: 2558083019668785839}
-  m_Layer: 12
+  m_Layer: 14
   m_Name: AxleField crossAxleReceptor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -21825,7 +21825,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019675068281}
   - component: {fileID: 2558083019675068278}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxB 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22150,7 +22150,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019687725388}
   - component: {fileID: 2558083019687725389}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22243,7 +22243,7 @@ GameObject:
   - component: {fileID: 2558083019687900872}
   - component: {fileID: 2558083019687900875}
   - component: {fileID: 2558083019687900874}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: 32123
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22382,7 +22382,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019693395925}
   - component: {fileID: 2558083019693395924}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22426,7 +22426,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019694587155}
   - component: {fileID: 2558083019694587154}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22470,7 +22470,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019698406443}
   - component: {fileID: 2558083019698406440}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Collision Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22514,7 +22514,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2558083019700656907}
   - component: {fileID: 2558083019700656904}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: TubeBoxA 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22753,7 +22753,7 @@ GameObject:
   - component: {fileID: 2558083019711408889}
   - component: {fileID: 2558083019711408887}
   - component: {fileID: 2558083019711408886}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Shell
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22836,7 +22836,7 @@ GameObject:
   - component: {fileID: 919302930704470096}
   - component: {fileID: 9099927618207105878}
   - component: {fileID: 6646635510088956619}
-  m_Layer: 0
+  m_Layer: 14
   m_Name: Main model
   m_TagString: Interactable
   m_Icon: {fileID: 0}

--- a/ProjectSettings/DynamicsManager.asset
+++ b/ProjectSettings/DynamicsManager.asset
@@ -7,6 +7,7 @@ PhysicsManager:
   m_Gravity: {x: 0, y: -9.81, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
+  m_DefaultMaxDepenetrationVelocity: 10
   m_SleepThreshold: 0.005
   m_DefaultContactOffset: 0.01
   m_DefaultSolverIterations: 6
@@ -17,7 +18,7 @@ PhysicsManager:
   m_ClothInterCollisionDistance: 0.1
   m_ClothInterCollisionStiffness: 0.2
   m_ContactsGeneration: 1
-  m_LayerCollisionMatrix: c9caffffc8c0ffffc8c0ffffffffffffc8c0ffffc8c0ffffffffffffffffffffc8f0ffffc9ccffffc8c2ffffc9c2ffffc8c1ffffc8c1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: c98affffc880ffffc880ffffffffffffc880ffffc880ffffffffffffffffffffc8f0ffffc98cffffc882ffffc982ffffc881ffffc881ffffc881ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   m_AutoSimulation: 1
   m_AutoSyncTransforms: 0
   m_ReuseCollisionCallbacks: 0


### PR DESCRIPTION
Fixes the player sometimes glitching through the ground or getting killed when using a lever.