### PR TITLE
Make camera collide with objects

### DIFF
--- a/Assets/Final Project/Prefabs/Badman/PlayerContainer.prefab
+++ b/Assets/Final Project/Prefabs/Badman/PlayerContainer.prefab
@@ -2580,7 +2580,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_CollideAgainst:
     serializedVersion: 2
-    m_Bits: 2048
+    m_Bits: 31745
   m_IgnoreTag: 
   m_TransparentLayers:
     serializedVersion: 2


### PR DESCRIPTION
The camera now collides with all objects, so the player won't be able to look through walls anymore.